### PR TITLE
inherit the original middleware's name

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,9 +13,11 @@ function convert (mw) {
     // assume it's Promise-based middleware
     return mw
   }
-  return function (ctx, next) {
+  const converted = function (ctx, next) {
     return co.call(ctx, mw.call(ctx, createGenerator(next)))
   }
+  converted._name = mw._name || mw.name
+  return converted
 }
 
 function * createGenerator (next) {

--- a/test.js
+++ b/test.js
@@ -25,6 +25,11 @@ describe('convert()', () => {
     })
   })
 
+  it('should inherit the original middleware name', () => {
+    let mw = convert(function * testing (next) {})
+    assert.strictEqual(mw._name, 'testing')
+  })
+
   it('should work with `yield next`', () => {
     let call = []
     let ctx = {}


### PR DESCRIPTION
Hi! Unfortunately the names of converted middlewares are missing from `DEBUG=koa*` output .. this restores them.. cheers!
